### PR TITLE
未完成データが存在するのにそれ以降の時間で登録できることを阻止(不整合データになってしまうため)

### DIFF
--- a/src/app/_types/apiRequests/dashboard/allSleepData/postResponse.ts
+++ b/src/app/_types/apiRequests/dashboard/allSleepData/postResponse.ts
@@ -1,4 +1,5 @@
 export interface PostResonse {
   status: 200;
-  id: number;
+  id?: number;
+  message: string;
 }

--- a/src/app/dashboard/sleep/_component/InputAllModal.tsx
+++ b/src/app/dashboard/sleep/_component/InputAllModal.tsx
@@ -25,14 +25,20 @@ export const InputAllModal: React.FC<Props> = ({
       wakeup: allDatetime.wakeup,
     };
     try {
-      await fetcher.post<PostRequest, PostResonse>(
+      const resp = await fetcher.post<PostRequest, PostResonse>(
         "/api/dashboard/allSleepData",
         body
       );
+      if (resp.status !== 200) {
+        throw new Error(resp.message);
+      }
       mutate();
-      setAllIsModalOpen(false);
     } catch (e) {
-      alert("登録に失敗しました");
+      if (e instanceof Error) {
+        alert(e.message);
+      }
+    } finally {
+      setAllIsModalOpen(false);
     }
   };
 


### PR DESCRIPTION
一括登録ならどんなデータでも登録出来ていましたが、以前友人がログイン出来なくなった時にデータを確認するとまだ起きていないのに寝た日時より後の時間で登録があり、エラー発生していたのでこのパターンをブロックした方が良いかもと思い、追加しました。

ご確認よろしくお願い致します。